### PR TITLE
Feat/add operator() and index()

### DIFF
--- a/include/cnda/contiguous_nd.hpp
+++ b/include/cnda/contiguous_nd.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <stdexcept>
 #include <numeric>
+#include <initializer_list>
 
 namespace cnda {
 
@@ -48,7 +49,84 @@ public:
   std::size_t                      size()    const { return m_size;    }
   T*                               data()          { return m_buffer.data(); }
   const T*                         data()    const { return m_buffer.data(); }
-
+  // -------- Index helpers --------
+  // Compute flat row-major index from an initializer_list of indices.
+  // If CNDA_BOUNDS_CHECK is defined, validates ndim and bounds.
+  std::size_t index(std::initializer_list<std::size_t> idxs) const {
+    std::size_t off = 0;
+#ifdef CNDA_BOUNDS_CHECK
+    if (idxs.size() != m_ndim) {
+      throw std::out_of_range("index: rank mismatch");
+    }
+#endif
+    std::size_t axis = 0;
+    for (auto v : idxs) {
+#ifdef CNDA_BOUNDS_CHECK
+      if (axis >= m_ndim) {
+        throw std::out_of_range("index: rank mismatch");
+      }
+      if (v >= m_shape[axis]) {
+        throw std::out_of_range("index: out of bounds");
+      }
+#endif
+      off += v * m_strides[axis];
+      ++axis;
+    }
+    return off;
+  }
+  // -------- operator() overloads (1D/2D/3D) --------
+  // 1D
+  T& operator()(std::size_t i) {
+#ifdef CNDA_BOUNDS_CHECK
+    if (m_ndim != 1 || i >= m_shape[0]) {
+      throw std::out_of_range("operator(): out of bounds (1D)");
+    }
+#endif
+    return m_buffer[i];
+  }
+  const T& operator()(std::size_t i) const {
+#ifdef CNDA_BOUNDS_CHECK
+    if (m_ndim != 1 || i >= m_shape[0]) {
+      throw std::out_of_range("operator() const: out of bounds (1D)");
+    }
+#endif
+    return m_buffer[i];
+  }
+  // 2D
+  T& operator()(std::size_t i, std::size_t j) {
+#ifdef CNDA_BOUNDS_CHECK
+    if (m_ndim != 2 || i >= m_shape[0] || j >= m_shape[1]) {
+      throw std::out_of_range("operator(): out of bounds (2D)");
+    }
+#endif
+    return m_buffer[i * m_strides[0] + j * m_strides[1]];
+  }
+  const T& operator()(std::size_t i, std::size_t j) const {
+#ifdef CNDA_BOUNDS_CHECK
+    if (m_ndim != 2 || i >= m_shape[0] || j >= m_shape[1]) {
+      throw std::out_of_range("operator() const: out of bounds (2D)");
+    }
+#endif
+    return m_buffer[i * m_strides[0] + j * m_strides[1]];
+  }
+  // 3D
+  T& operator()(std::size_t i, std::size_t j, std::size_t k) {
+#ifdef CNDA_BOUNDS_CHECK
+    if (m_ndim != 3 || i >= m_shape[0] || j >= m_shape[1] || k >= m_shape[2]) {
+      throw std::out_of_range("operator(): out of bounds (3D)");
+    }
+#endif
+    return m_buffer[i * m_strides[0] + j * m_strides[1] + k * m_strides[2]];
+  }
+  const T& operator()(std::size_t i, std::size_t j, std::size_t k) const {
+#ifdef CNDA_BOUNDS_CHECK
+    if (m_ndim != 3 || i >= m_shape[0] || j >= m_shape[1] || k >= m_shape[2]) {
+      throw std::out_of_range("operator() const: out of bounds (3D)");
+    }
+#endif
+    return m_buffer[i * m_strides[0] + j * m_strides[1] + k * m_strides[2]];
+  }
+  
 private:
   std::vector<std::size_t> m_shape;
   std::vector<std::size_t> m_strides; // in ELEMENTS (not bytes)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ FetchContent_MakeAvailable(catch2)
 
 add_executable(test_sanity test_sanity.cpp)
 target_link_libraries(test_sanity PRIVATE Catch2::Catch2WithMain cnda_headers)
+target_compile_definitions(test_sanity PRIVATE CNDA_BOUNDS_CHECK)
 
 # 讓 CTest 能發現並執行
 include(Catch)


### PR DESCRIPTION
- [x] Implemented 1D/2D/3D `operator()` read/write access
- [x] Added `index(std::initializer_list<size_t>)` for element-wise linear offset calculation
- [x] Added `CNDA_BOUNDS_CHECK`: throws `std::out_of_range` on dimension mismatch or out-of-bounds access
- [x] Added Catch2 tests:

  - [x] Valid indices return correct elements
  - [x] Out-of-bounds indices throw exceptions when bounds checking is enabled
- [x] Acceptance test: `a(1, 2)` retrieves the expected element

-  Fixes #4 