### PR TITLE
Enable ContiguousND across common dtypes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(catch2)
 
-add_executable(test_sanity test_sanity.cpp)
+add_executable(test_sanity test_sanity.cpp test_dtypes.cpp)
 target_link_libraries(test_sanity PRIVATE Catch2::Catch2WithMain cnda_headers)
 target_compile_definitions(test_sanity PRIVATE CNDA_BOUNDS_CHECK)
 

--- a/tests/test_dtypes.cpp
+++ b/tests/test_dtypes.cpp
@@ -1,0 +1,37 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <cnda/contiguous_nd.hpp>
+#include <cstdint>
+
+TEMPLATE_TEST_CASE("ContiguousND supports common dtypes", "[dtype]",
+                   float, double, std::int32_t, std::int64_t)
+{
+    // 2D basic: shape, strides, size
+    cnda::ContiguousND<TestType> a({3, 4});
+    REQUIRE(a.ndim() == 2);
+    REQUIRE(a.size() == static_cast<std::size_t>(12));
+    REQUIRE(a.shape()[0] == 3);
+    REQUIRE(a.shape()[1] == 4);
+    REQUIRE(a.strides()[0] == 4);
+    REQUIRE(a.strides()[1] == 1);
+
+    // write/read using operator()(i,j)
+    TestType v = static_cast<TestType>(42);
+    a(1, 2) = v;
+    REQUIRE(a(1, 2) == v);
+
+    // cross-check index() mapping
+    auto off = a.index({1, 2});
+    REQUIRE(off == 6);
+
+    // 1D case
+    cnda::ContiguousND<TestType> b({5});
+    for (std::size_t i = 0; i < 5; ++i) b(i) = static_cast<TestType>(i);
+    REQUIRE(b(4) == static_cast<TestType>(4));
+
+    // 3D write/read
+    cnda::ContiguousND<TestType> c({2, 3, 4});
+    TestType vv = static_cast<TestType>(7);
+    c(1, 1, 2) = vv;
+    REQUIRE(c(1, 1, 2) == vv);
+}


### PR DESCRIPTION
* [x] Unified template implementation for `ContiguousND<T>` supporting: `float`, `double`, `std::int32_t`, `std::int64_t`
* [x] Added Catch2 **parameterized tests** for all supported dtypes
* [x] Verified **2D row-major layout**:

  * [x] `shape() == {3, 4}`
  * [x] `strides() == {4, 1}`
  * [x] `size() == 12`
* [x] Write/read test using `operator()(i,j)` and 3D indexing:

  * [x] `a(1,2)` stores and retrieves `42`
  * [x] `c(1,1,2)` stores and retrieves `7`
* [x] Cross-check linear offset mapping:

  * [x] `a.index({1,2}) == 6`
* [x] 1D indexing test:

  * [x] `b(4)` stores and retrieves `4`
 
* Fix #5 